### PR TITLE
Add write to stream; fix start position issue

### DIFF
--- a/FlatFileGenerator/FlatFile.cs
+++ b/FlatFileGenerator/FlatFile.cs
@@ -10,7 +10,7 @@ namespace FlatFile {
 	/// Outputs a flat file of type T.
 	/// </summary>
 	/// <typeparam name="T">The type of the file to write, with properties that implement <see cref="FlatFileAttribute"/>.</typeparam>
-	public sealed class FlatFile<T> {
+	public sealed class FlatFile<T> where T : IFlatFile {
 		public void WriteFile( List<T> records, string filePath ) {
 			// Make sure there are records to write
 			if( records.Count == 0 )
@@ -80,6 +80,14 @@ namespace FlatFile {
 					var rightSide = dataRow.Substring( start, dataRow.Length );
 					dataRow = leftSide + outputString + rightSide;
 				}
+			}
+
+			if( record.FixedLineWidth > 0 ) {
+				// row has a fixed width, trim or extend to specified length
+				if( dataRow.Length > record.FixedLineWidth )
+					dataRow = dataRow.Substring( 0, record.FixedLineWidth );
+				else if( dataRow.Length < record.FixedLineWidth )
+					dataRow = dataRow.PadRight( record.FixedLineWidth );
 			}
 
 			return dataRow;

--- a/FlatFileGenerator/FlatFile.cs
+++ b/FlatFileGenerator/FlatFile.cs
@@ -5,71 +5,84 @@ using System.Text;
 using System.Reflection;
 using System.IO;
 
-namespace FlatFile
-{
-    class FlatFile<T>
-    {
-        public void writeFile(List<T> records, string filePath)
-        {
-            // Make sure there are records to write
-            if (records.Count > 0)
-            {
-                Type t = records[0].GetType();
-                PropertyInfo[] pi = t.GetProperties();
+namespace FlatFile {
+	/// <summary>
+	/// Outputs a flat file of type T.
+	/// </summary>
+	/// <typeparam name="T">The type of the file to write, with properties that implement <see cref="FlatFileAttribute"/>.</typeparam>
+	public sealed class FlatFile<T> {
+		public void WriteFile( List<T> records, string filePath ) {
+			// Make sure there are records to write
+			if( records.Count == 0 )
+				return;
+			var t = records[ 0 ].GetType( );
+			var pi = t.GetProperties( );
 
-                using (StreamWriter writer = File.CreateText(filePath))
-                {
-                    foreach (T record in records)
-                    {
-                        string dataRow = string.Empty;
+			using( var writer = File.CreateText( filePath ) ) {
+				foreach( var line in records.Select( record => createLine( record, pi ) ) ) {
+					// write to file
+					writer.WriteLine( line );
+				}
+			}
+		}
 
-                        foreach (PropertyInfo p in pi)
-                        {
-                            object[] attributes = p.GetCustomAttributes(typeof(FlatFileAttribute), false);
-                            FlatFileAttribute ffa = null;
-                            int start = 0, length = 0;
+		public void WriteFile( List<T> records, Stream stream ) {
+			// Make sure there are records to write
+			if( records.Count == 0 )
+				return;
+			var t = records[ 0 ].GetType( );
+			var pi = t.GetProperties( );
 
-                            if (attributes.Length > 0)
-                            {
-                                ffa = (FlatFileAttribute)attributes[0];
-                            }
+			foreach( var lineBytes in records.Select( record => createLine( record, pi ) ).Select( stringToBytes ) ) {
+				// write to file
+				stream.Write( lineBytes, 0, lineBytes.Length );
+			}
+		}
 
-                            if (ffa != null)
-                            {
-                                start = ffa.startPosition;
-                                length = ffa.fieldLength;
-                            }
+		private static byte[ ] stringToBytes( string text ) {
+			var bytes = new ASCIIEncoding( ).GetBytes( text + Environment.NewLine );
+			return bytes;
+		}
 
-                            string outputString = p.GetValue(record, null).ToString();
-                            if (outputString.Length < length)
-                            {
-                                outputString = outputString.PadRight(length);
-                            }
+		private static string createLine( T record, IEnumerable<PropertyInfo> pi ) {
+			var dataRow = String.Empty;
 
-                            if (outputString.Length == length)
-                            {
-                                if (dataRow.Length < start)
-                                {
-                                    dataRow += outputString;
-                                }
-                                else
-                                {
-                                    // current field falls inside the middle of the existing output string.
-                                    // split based on start position and then concatenate
-                                    string leftSide = string.Empty, rightSide = string.Empty;
-                                    leftSide = dataRow.Substring(0, start - 1);
-                                    rightSide = dataRow.Substring(start, dataRow.Length);
-                                    dataRow = leftSide + outputString + rightSide;
-                                }
-                            }
-                        }
+			foreach( var p in pi ) {
+				var attributes = p.GetCustomAttributes( typeof( FlatFileAttribute ), false );
+				FlatFileAttribute ffa = null;
+				int start = 0, length = 0;
 
-                        // write to file
-                        writer.WriteLine(dataRow);
-                    }
-                }
-            }
-        }
-    }
+				if( attributes.Length > 0 ) {
+					ffa = (FlatFileAttribute) attributes[ 0 ];
+				}
 
+				if( ffa != null ) {
+					start = ffa.StartPosition;
+					length = ffa.FieldLength;
+				}
+
+				var outputString = p.GetValue( record, null ).ToString( );
+				if( outputString.Length < length ) {
+					outputString = outputString.PadRight( length );
+				} else if( outputString.Length > length ) {
+					outputString = outputString.Substring( 0, length );
+				}
+
+				if( dataRow.Length + 1 == start ) {
+					dataRow += outputString;
+				} else if( dataRow.Length < start ) {
+					// need to extend the line out
+					dataRow = dataRow.PadRight( start - 1 ) + outputString;
+				} else {
+					// current field falls inside the middle of the existing output string.
+					// split based on start position and then concatenate
+					var leftSide = dataRow.Substring( 0, start - 1 );
+					var rightSide = dataRow.Substring( start, dataRow.Length );
+					dataRow = leftSide + outputString + rightSide;
+				}
+			}
+
+			return dataRow;
+		}
+	}
 }

--- a/FlatFileGenerator/FlatFile.cs
+++ b/FlatFileGenerator/FlatFile.cs
@@ -46,7 +46,6 @@ namespace FlatFile {
 			foreach( var p in pi ) {
 				var attributes = p.GetCustomAttributes( typeof( FlatFileAttribute ), false );
 				FlatFileAttribute ffa = null;
-				int start = 0, length = 0;
 
 				if( attributes.Length > 0 ) {
 					ffa = attributes[ 0 ] as FlatFileAttribute;
@@ -56,8 +55,8 @@ namespace FlatFile {
 					// skip properties without the FlatFileAttribute (e.g., IFlatFile.FixedLineWidth)
 					continue;
 
-				start = ffa.StartPosition;
-				length = ffa.FieldLength;
+				var start = ffa.StartPosition;
+				var length = ffa.FieldLength;
 
 				var outputString = Convert.ToString( p.GetValue( record, null ) );
 				if( outputString.Length < length ) {

--- a/FlatFileGenerator/FlatFile.cs
+++ b/FlatFileGenerator/FlatFile.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Reflection;
 using System.IO;
 
 namespace FlatFile {
@@ -15,11 +14,9 @@ namespace FlatFile {
 			// Make sure there are records to write
 			if( records.Count == 0 )
 				return;
-			var t = records[ 0 ].GetType( );
-			var pi = t.GetProperties( );
 
 			using( var writer = File.CreateText( filePath ) ) {
-				foreach( var line in records.Select( record => createLine( record, pi ) ) ) {
+				foreach( var line in records.Select( createLine ) ) {
 					// write to file
 					writer.WriteLine( line );
 				}
@@ -30,10 +27,8 @@ namespace FlatFile {
 			// Make sure there are records to write
 			if( records.Count == 0 )
 				return;
-			var t = records[ 0 ].GetType( );
-			var pi = t.GetProperties( );
 
-			foreach( var lineBytes in records.Select( record => createLine( record, pi ) ).Select( stringToBytes ) ) {
+			foreach( var lineBytes in records.Select( createLine ).Select( stringToBytes ) ) {
 				// write to file
 				stream.Write( lineBytes, 0, lineBytes.Length );
 			}
@@ -44,8 +39,9 @@ namespace FlatFile {
 			return bytes;
 		}
 
-		private static string createLine( T record, IEnumerable<PropertyInfo> pi ) {
+		private static string createLine( T record ) {
 			var dataRow = String.Empty;
+			var pi = record.GetType( ).GetProperties( );
 
 			foreach( var p in pi ) {
 				var attributes = p.GetCustomAttributes( typeof( FlatFileAttribute ), false );
@@ -53,7 +49,7 @@ namespace FlatFile {
 				int start = 0, length = 0;
 
 				if( attributes.Length > 0 ) {
-					ffa = (FlatFileAttribute) attributes[ 0 ];
+					ffa = attributes[ 0 ] as FlatFileAttribute;
 				}
 
 				if( ffa != null ) {

--- a/FlatFileGenerator/FlatFile.cs
+++ b/FlatFileGenerator/FlatFile.cs
@@ -52,12 +52,14 @@ namespace FlatFile {
 					ffa = attributes[ 0 ] as FlatFileAttribute;
 				}
 
-				if( ffa != null ) {
-					start = ffa.StartPosition;
-					length = ffa.FieldLength;
-				}
+				if( ffa == null )
+					// skip properties without the FlatFileAttribute (e.g., IFlatFile.FixedLineWidth)
+					continue;
 
-				var outputString = p.GetValue( record, null ).ToString( );
+				start = ffa.StartPosition;
+				length = ffa.FieldLength;
+
+				var outputString = Convert.ToString( p.GetValue( record, null ) );
 				if( outputString.Length < length ) {
 					outputString = outputString.PadRight( length );
 				} else if( outputString.Length > length ) {

--- a/FlatFileGenerator/FlatFileAttribute.cs
+++ b/FlatFileGenerator/FlatFileAttribute.cs
@@ -1,21 +1,18 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FlatFile
 {
-    [AttributeUsage(AttributeTargets.All)]
-    public class FlatFileAttribute : System.Attribute
-    {
-        public int fieldLength { get; private set; }
-        public int startPosition { get; private set; }
+	/// <summary>
+	/// Attribute for defining a field in a flat file.
+	/// </summary>
+	[AttributeUsage( AttributeTargets.All )]
+	public sealed class FlatFileAttribute : Attribute {
+		public int FieldLength { get; private set; }
+		public int StartPosition { get; private set; }
 
-        public FlatFileAttribute(int startPosition, int fieldLength)
-        {
-            this.startPosition = startPosition;
-            this.fieldLength = fieldLength;
-        }
-    }
-
+		public FlatFileAttribute( int startPosition, int fieldLength ) {
+			this.StartPosition = startPosition;
+			this.FieldLength = fieldLength;
+		}
+	}
 }

--- a/FlatFileGenerator/FlatFileBase.cs
+++ b/FlatFileGenerator/FlatFileBase.cs
@@ -1,0 +1,12 @@
+﻿namespace FlatFile {
+	/// <summary>
+	/// Abstract class for flat file definitions so that you don't have to implement FixedLineWidth where it's not used.
+	/// </summary>
+	public abstract class FlatFileBase : IFlatFile {
+		/// <summary>
+		/// Defines the line length, when it is a fixed length. Should only be necessary when there's not a field at the very end of the line.
+		/// </summary>
+		/// <remarks>When zero (0), this setting should be ignored.</remarks>
+		public virtual int FixedLineWidth { get { return 0; } }
+	}
+}

--- a/FlatFileGenerator/FlatFileGenerator.csproj
+++ b/FlatFileGenerator/FlatFileGenerator.csproj
@@ -42,6 +42,8 @@
   <ItemGroup>
     <Compile Include="FlatFile.cs" />
     <Compile Include="FlatFileAttribute.cs" />
+    <Compile Include="FlatFileBase.cs" />
+    <Compile Include="IFlatFile.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/FlatFileGenerator/IFlatFile.cs
+++ b/FlatFileGenerator/IFlatFile.cs
@@ -1,0 +1,9 @@
+﻿namespace FlatFile {
+	public interface IFlatFile {
+		/// <summary>
+		/// Defines the line length, when it is a fixed length. Should only be necessary when there's not a field at the very end of the line.
+		/// </summary>
+		/// <remarks>When zero (0), this setting should be ignored.</remarks>
+		int FixedLineWidth { get; }
+	}
+}


### PR DESCRIPTION
We needed to be able to write to a stream (which also allows us to create different classes and write to the stream; e.g., a header record, detail records, and a footer record). In addition, there was an issue when the new field was at a position well after the end of the previous field. As an example, one format we use had the following definitions:

Record type: 1, 4
Version: 5, 9
Group: 14, 30
Timestamp: 64, 24

There's a gap between group and timestamp (my guess is there are other fields that go there that we don't use, but we don't have the original file spec anymore), but the existing code would just append the timestamp to the end of the group - which is not the right location.

Also added a trim to the field if it was too long, rather than skipping it entirely as the current code would do.
